### PR TITLE
Fix top-level market order execution

### DIFF
--- a/tests/robinhood_auth_test.py
+++ b/tests/robinhood_auth_test.py
@@ -100,7 +100,8 @@ def place_market_order(symbol, side, usd_amount):
         print("Error placing order:", e)
         return None
 
-# Main execution
-print("Calling place_market_order...")
-order_response = place_market_order("BTC-USD", "buy", 5)
-print("Order Response:", order_response)
+if __name__ == "__main__":
+    # Main execution
+    print("Calling place_market_order...")
+    order_response = place_market_order("BTC-USD", "buy", 5)
+    print("Order Response:", order_response)


### PR DESCRIPTION
## Summary
- prevent `tests/robinhood_auth_test.py` from issuing API calls on import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9dfd12208320bd2f36772c597b70