### PR TITLE
Remove unnecessary comment

### DIFF
--- a/tests/robinhood_auth_test.py
+++ b/tests/robinhood_auth_test.py
@@ -1,7 +1,7 @@
 import requests
 import base64
 import time
-import json  # Missing import added
+import json  
 import uuid
 from nacl.signing import SigningKey
 


### PR DESCRIPTION
## Summary
- remove leftover comment about missing import in `robinhood_auth_test.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9e022c8883209d0d69718eddab10